### PR TITLE
Add Tecware Phantom RGB

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A Mechanical Keyboard Database
 | Redragon     | K552-1         | VS11K09A            | WIP                                                  |                                                              | RGB       | Yes     | No       |        |
 | Redragon     | K552-2         | VS11K09A-1          | WIP                                                  |                                                              | RGB       | Yes     | No       |        |
 | Glorious PC Gaming Race | GMMK TKL 2020  | VS11K13A            | No                                                   |                                                              | RGB       | Yes     | No       |        |
+| Tecware | Phantom RGB | VS11K13A | No | | RGB | Yes (Outemu Only) | No | |
 | iKBC | F87 RGB | HT32F1854 | No | | RGB | No | No |  |
 | GANSS | GS87D | HFD48KP500 | No | | White | No | Bluetooth 3.0 |  |
 | Ajazz | K870T | HFD2201KBA | No | | RGB | No | Bluetooth 5.0 | |


### PR DESCRIPTION
[Teardown article here.](https://www.techpowerup.com/review/tecware-phantom-rgb/4.html) Confirmed VS11K13A in my board. Added detail of Outemu sockets, since they're smaller than regular Kailh sockets, so they only fit Outemu switches unless you file down or squish the pins of another brand of switch.

Some more details about this board:
* Non removable cable
* Almost identical to GMMK TKL, I expect that they're using the same vendor